### PR TITLE
refactor: Add error trait bound to generic error type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ documentation = "https://docs.rs/max3010x"
 [dependencies]
 embedded-hal = "1.0.0"
 nb = "1"
+rustversion = "1.0.20"
 thiserror = { version = "2.0.12", default-features = false }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ documentation = "https://docs.rs/max3010x"
 [dependencies]
 embedded-hal = "1.0.0"
 nb = "1"
+thiserror = { version = "2.0.12", default-features = false }
 
 [dev-dependencies]
 linux-embedded-hal = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,11 +136,13 @@ extern crate nb;
 use core::marker::PhantomData;
 
 /// All possible errors in this crate
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error<E> {
     /// I²C bus error
-    I2C(E),
+    #[error(transparent)]
+    I2C(#[from] E),
     /// Invalid arguments provided
+    #[error("Invalid arguments provided")]
     InvalidArguments,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,9 @@ use hal::i2c;
 extern crate nb;
 use core::marker::PhantomData;
 
+
 /// All possible errors in this crate
+#[rustversion::since(1.81)]
 #[derive(Debug, thiserror::Error)]
 pub enum Error<E> {
     /// I²C bus error
@@ -143,6 +145,15 @@ pub enum Error<E> {
     I2C(#[from] E),
     /// Invalid arguments provided
     #[error("Invalid arguments provided")]
+    InvalidArguments,
+}
+
+/// All possible errors in this crate
+#[rustversion::before(1.81)]
+pub enum Error<E> {
+    /// I²C bus error
+    I2C(E),
+    /// Invalid arguments provided
     InvalidArguments,
 }
 


### PR DESCRIPTION
Thank you for the great library! I would like to improve its error handling by adding the `Error` trait bound to your error type, so that it is compatible with crates such as `anyhow`. For example when I use the `?` operator in a function that returns an `anyhow::Result` I have to append `map_err` to each method call.